### PR TITLE
Feat: Custom macros, boolean feedbacks, new presets, fixes for pgm/pvw/tally variables and feedbacks

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -18,7 +18,8 @@ Allows you to control the Tricaster line of video production switchers from NewT
 - Set Source to DSK per ME (A & B bus)
 - Media options
   - Play/Play Toggle/Stop/Back/Forward
-- Run Macro's (under construction)
+- Run System Macros
+- Trigger Custom Macros
 - Record start/stop
 - Streaming Toggle
 - Set a DataLink key/value

--- a/HELP.md
+++ b/HELP.md
@@ -1,46 +1,51 @@
-## companion-module-newtec-tricaster
+## companion-module-newtek-tricaster
+
+Allows you to control the Tricaster line of video production switchers from NewTek.
 
 ### Configuration
-* Instructions here about information needed to connect to the device/software.
+
+- On the Tricaster under Administration Tools, turn off the LivePanel password
+- Enter the IP address of the Tricaster in the module settings
+- _Optional: To get variables from DataLink, enable polling in the module settings. The interval must be at least 500ms_
 
 ### Available Actions
-* Take
-* Auto transition (also on dsk)
-* Set Source to preview
-* Set Source to program
-* Set Source to V (ME)
-* Set Source to DSK per ME
-** a & b bus
-* Media options
-** Play/Play Toggle/Stop/Back/Forward
-* Run Macro's (under construction)
-* Record start/stop
-* Streaming Toggle
-* Set a datalink key/value
-* Custom Shortcuts
+
+- Take
+- Auto transition (also on dsk)
+- Set Source to preview
+- Set Source to program
+- Set Source to V (ME)
+- Set Source to DSK per ME (A & B bus)
+- Media options
+  - Play/Play Toggle/Stop/Back/Forward
+- Run Macro's (under construction)
+- Record start/stop
+- Streaming Toggle
+- Set a DataLink key/value
+- Custom Shortcuts
 
 ### Available Feedbacks
-* Tally feedback for sources on program and preview
-* Media feedback (under construction)
-* Record
-* Stream
+
+- Tally feedback for sources on program and preview
+- Media feedback (under construction)
+- Record
+- Stream
 
 ### Available Variables
-* Product name
-* Product version
-* Source on program
-* Source on preview
-* All inputs
-* All Datalink key/value pairs
+
+- Product name
+- Product version
+- Source on program
+- Source on preview
+- All inputs
+- All DataLink key/value pairs _Note: must enable polling in the module settings_
 
 ### Available Presets
-* Sources to PGM
-* Sources to PVW
-* Sources to V1
-* Take
-* Auto
-* Record toggle
-* Streaming
 
-### Datalink
-All variables are being polled at the moment, set an interval (minimum of 500ms)
+- Sources to PGM
+- Sources to PVW
+- Sources to V1
+- Take
+- Auto
+- Record toggle
+- Streaming

--- a/HELP.md
+++ b/HELP.md
@@ -44,7 +44,7 @@ Allows you to control the Tricaster line of video production switchers from NewT
 
 - Sources to PGM
 - Sources to PVW
-- Sources to V1
+- Sources to M/E 1
 - Take
 - Auto
 - Record Toggle

--- a/HELP.md
+++ b/HELP.md
@@ -26,18 +26,18 @@ Allows you to control the Tricaster line of video production switchers from NewT
 
 ### Available Feedbacks
 
-- Tally feedback for sources on program and preview
-- Media feedback (under construction)
+- Source Tally (Program and Preview)
+- Media Playing (DDRs, GFX, Stills, Titles, Sound)
 - Record
 - Stream
 
 ### Available Variables
 
-- Product name
-- Product version
-- Source on program
-- Source on preview
-- All inputs
+- Product Name
+- Product Version
+- Source on Program
+- Source on Preview
+- Input Names
 - All DataLink key/value pairs _Note: must enable polling in the module settings_
 
 ### Available Presets
@@ -47,5 +47,5 @@ Allows you to control the Tricaster line of video production switchers from NewT
 - Sources to V1
 - Take
 - Auto
-- Record toggle
+- Record Toggle
 - Streaming

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ See HELP.md & LICENSE
 
 
 ## Documentation about the protocol ##
-[pdf docu](http://a6ce85f34b101e4ba428-38e91d4533ffbe5c8042650a77a3ed34.r56.cf1.rackcdn.com/TriCaster/AI%20Guide/Automation%20and%20Integration%20Guide.pdf)
+[PDF](http://a6ce85f34b101e4ba428-38e91d4533ffbe5c8042650a77a3ed34.r56.cf1.rackcdn.com/TriCaster/AI%20Guide/Automation%20and%20Integration%20Guide.pdf)
 
 ## Help file for shortcuts ##
-[docu](https://jonjones.co/blog/newtek-tricaster-network-control-advanced-edition/)
+[PDF](https://jonjones.co/blog/newtek-tricaster-network-control-advanced-edition/)
 

--- a/actions.js
+++ b/actions.js
@@ -39,13 +39,14 @@ module.exports = {
 			],
 		}
 		actions['trigger'] = {
-			label: 'Trigger Marco',
+			label: 'Trigger Custom Marco',
 			options: [
 				{
-					label: 'trigger',
-					type: 'textinput',
+					label: 'Macro Name',
+					type: 'dropdown',
+					choices: this.custom_macros,
 					id: 'macro',
-					default: '',
+					default: this.custom_macros[0] ? this.custom_macros[0].id : 'Macro Name',
 				},
 			],
 		}
@@ -353,7 +354,6 @@ module.exports = {
 				},
 			],
 		}
-
 		return actions
 	},
 }

--- a/actions.js
+++ b/actions.js
@@ -11,10 +11,10 @@ module.exports = {
 					label: 'Choose dsk',
 					type: 'dropdown',
 					choices: [
-						{ id: 'dsk1', label: 'dsk 1' },
-						{ id: 'dsk2', label: 'dsk 2' },
-						{ id: 'dsk3', label: 'dsk 3' },
-						{ id: 'dsk4', label: 'dsk 4' },
+						{ id: 'dsk1', label: 'DSK 1' },
+						{ id: 'dsk2', label: 'DSK 2' },
+						{ id: 'dsk3', label: 'DSK 3' },
+						{ id: 'dsk4', label: 'DSK 4' },
 					],
 					id: 'dsk',
 					default: 'dsk1',
@@ -105,7 +105,7 @@ module.exports = {
 			],
 		}
 		actions['source_to_dsk'] = {
-			label: 'Set source to dsk',
+			label: 'Set source to DSK',
 			options: [
 				{
 					label: 'Destination',
@@ -143,10 +143,10 @@ module.exports = {
 					type: 'dropdown',
 					id: 'target',
 					choices: [
-						{ id: 'ddr1', label: 'ddr 1' },
-						{ id: 'ddr2', label: 'ddr 2' },
-						{ id: 'ddr3', label: 'ddr 3' },
-						{ id: 'ddr4', label: 'ddr 4' },
+						{ id: 'ddr1', label: 'DDR 1' },
+						{ id: 'ddr2', label: 'DDR 2' },
+						{ id: 'ddr3', label: 'DDR 3' },
+						{ id: 'ddr4', label: 'DDR 4' },
 					],
 					default: 'ddr1',
 				},
@@ -163,16 +163,16 @@ module.exports = {
 			],
 		}
 		actions['datalink'] = {
-			label: 'Set datalink key value',
+			label: 'Set DataLink key value',
 			options: [
 				{
-					label: 'Datalink Key',
+					label: 'DataLink Key',
 					type: 'textinput',
 					id: 'datalink_key',
 					width: 6,
 				},
 				{
-					label: 'Datalink Value',
+					label: 'DataLink Value',
 					type: 'textinput',
 					id: 'datalink_value',
 					width: 6,
@@ -187,10 +187,10 @@ module.exports = {
 					type: 'dropdown',
 					id: 'source',
 					choices: [
-						{ id: 'ddr1', label: 'ddr 1' },
-						{ id: 'ddr2', label: 'ddr 2' },
-						{ id: 'ddr3', label: 'ddr 3' },
-						{ id: 'ddr4', label: 'ddr 4' },
+						{ id: 'ddr1', label: 'DDR 1' },
+						{ id: 'ddr2', label: 'DDR 2' },
+						{ id: 'ddr3', label: 'DDR 3' },
+						{ id: 'ddr4', label: 'DDR 4' },
 						{ id: 'sound', label: 'Sound' },
 						{ id: 'effects', label: 'Effects' },
 					],
@@ -214,10 +214,10 @@ module.exports = {
 					type: 'dropdown',
 					id: 'source',
 					choices: [
-						{ id: 'ddr1', label: 'ddr 1' },
-						{ id: 'ddr2', label: 'ddr 2' },
-						{ id: 'ddr3', label: 'ddr 3' },
-						{ id: 'ddr4', label: 'ddr 4' },
+						{ id: 'ddr1', label: 'DDR 1' },
+						{ id: 'ddr2', label: 'DDR 2' },
+						{ id: 'ddr3', label: 'DDR 3' },
+						{ id: 'ddr4', label: 'DDR 4' },
 						{ id: 'sound', label: 'Sound' },
 						{ id: 'effects', label: 'Effects' },
 					],
@@ -332,10 +332,10 @@ module.exports = {
 					label: 'Choose dsk',
 					type: 'dropdown',
 					choices: [
-						{ id: 'dsk1', label: 'dsk 1' },
-						{ id: 'dsk2', label: 'dsk 2' },
-						{ id: 'dsk3', label: 'dsk 3' },
-						{ id: 'dsk4', label: 'dsk 4' },
+						{ id: 'dsk1', label: 'DSK 1' },
+						{ id: 'dsk2', label: 'DSK 2' },
+						{ id: 'dsk3', label: 'DSK 3' },
+						{ id: 'dsk4', label: 'DSK 4' },
 					],
 					id: 'dsk',
 					default: 'dsk1',

--- a/actions.js
+++ b/actions.js
@@ -86,7 +86,7 @@ module.exports = {
 			],
 		}
 		actions['source_to_v'] = {
-			label: 'Set source to V',
+			label: 'Set source to M/E',
 			options: [
 				{
 					label: 'Destination',

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -3,33 +3,22 @@ const { resolve } = require('app-root-path')
 exports.initFeedbacks = function () {
 	const feedbacks = {}
 
-	const foregroundColor = {
-		type: 'colorpicker',
-		label: 'Foreground color',
-		id: 'fg',
-		default: this.rgb(255, 255, 255),
+	const feedbackColorPreview = {
+		color: this.rgb(255, 255, 255),
+		bgcolor: this.rgb(0, 255, 0),
 	}
 
-	const backgroundColorPreview = {
-		type: 'colorpicker',
-		label: 'Background color',
-		id: 'bg',
-		default: this.rgb(0, 255, 0),
-	}
-
-	const backgroundColorProgram = {
-		type: 'colorpicker',
-		label: 'Background color',
-		id: 'bg',
-		default: this.rgb(255, 0, 0),
+	const feedbackColorProgram = {
+		color: this.rgb(255, 255, 255),
+		bgcolor: this.rgb(255, 0, 0),
 	}
 
 	feedbacks.tally_PGM = {
-		label: 'Change color from program source',
-		description: 'When source is on-air, background color will change',
+		type: 'boolean',
+		label: 'Change style from program source',
+		description: 'When source is on-air, button style will change',
+		style: feedbackColorProgram,
 		options: [
-			foregroundColor,
-			backgroundColorProgram,
 			{
 				type: 'dropdown',
 				label: 'source',
@@ -41,11 +30,11 @@ exports.initFeedbacks = function () {
 	}
 
 	feedbacks.tally_PVW = {
-		label: 'Change color from preview source',
-		description: 'When source is on preview bus, background color will change',
+		type: 'boolean',
+		label: 'Change style from preview source',
+		description: 'When source is on preview bus, button style will change',
+		style: feedbackColorPreview,
 		options: [
-			foregroundColor,
-			backgroundColorPreview,
 			{
 				type: 'dropdown',
 				label: 'source',
@@ -57,23 +46,25 @@ exports.initFeedbacks = function () {
 	}
 
 	feedbacks.tally_record = {
-		label: 'Change color when recording',
-		description: 'When recording, background color will change',
-		options: [foregroundColor, backgroundColorProgram],
+		type: 'boolean',
+		label: 'Change style when recording',
+		description: 'When recording, button style will change',
+		style: feedbackColorProgram,
 	}
 
 	feedbacks.tally_streaming = {
-		label: 'Change color when streaming',
-		description: 'When streaming, background color will change',
-		options: [foregroundColor, backgroundColorProgram],
+		type: 'boolean',
+		label: 'Change style when streaming',
+		description: 'When streaming, button style will change',
+		style: feedbackColorProgram,
 	}
 
 	feedbacks.play_media = {
-		label: 'Change color when player is active',
-		description: 'When media state is on play, background color will change',
+		type: 'boolean',
+		label: 'Change style when player is active',
+		description: 'When media state is on play, button style will change',
+		style: feedbackColorProgram,
 		options: [
-			foregroundColor,
-			backgroundColorPreview,
 			{
 				type: 'dropdown',
 				label: 'target',
@@ -90,46 +81,33 @@ exports.initFeedbacks = function () {
 exports.executeFeedback = function (feedback, bank) {
 	if (feedback.type === 'tally_PGM') {
 		if (this.tallyPGM[feedback.options.src] == 'true') {
-			return {
-				color: feedback.options.fg,
-				bgcolor: feedback.options.bg,
-			}
+			return true
 		}
 	}
 
 	if (feedback.type === 'tally_PVW') {
 		if (this.tallyPVW[feedback.options.src] == 'true') {
-			return {
-				color: feedback.options.fg,
-				bgcolor: feedback.options.bg,
-			}
+			return true
 		}
 	}
 
 	if (feedback.type === 'tally_record') {
 		if (this.switcher['recording']) {
-			return {
-				color: feedback.options.fg,
-				bgcolor: feedback.options.bg,
-			}
+			return true
 		}
 	}
 
 	if (feedback.type === 'tally_streaming') {
 		if (this.switcher['streaming']) {
-			return {
-				color: feedback.options.fg,
-				bgcolor: feedback.options.bg,
-			}
+			return true
 		}
 	}
 
 	if (feedback.type === 'play_media') {
 		if (this.shortcut_states[feedback.options.target] == 'true') {
-			return {
-				color: feedback.options.fg,
-				bgcolor: feedback.options.bg,
-			}
+			return true
 		}
 	}
+
+	return false
 }

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -59,6 +59,15 @@ exports.initFeedbacks = function () {
 		style: feedbackColorProgram,
 	}
 
+	let playMediaChoices = []
+
+	this.mediaSourceNames.forEach((source) => {
+		playMediaChoices.push({
+			id: `${source.id}_play`,
+			label: `${source.label}`,
+		})
+	})
+
 	feedbacks.play_media = {
 		type: 'boolean',
 		label: 'Change style when player is active',
@@ -69,7 +78,7 @@ exports.initFeedbacks = function () {
 				type: 'dropdown',
 				label: 'Media Player',
 				id: 'target',
-				choices: this.mediaSourceNames,
+				choices: playMediaChoices,
 				default: 'ddr1_play',
 			},
 		],

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -21,7 +21,7 @@ exports.initFeedbacks = function () {
 		options: [
 			{
 				type: 'dropdown',
-				label: 'source',
+				label: 'Source',
 				id: 'src',
 				choices: this.inputs,
 				default: 0,
@@ -37,7 +37,7 @@ exports.initFeedbacks = function () {
 		options: [
 			{
 				type: 'dropdown',
-				label: 'source',
+				label: 'Source',
 				id: 'src',
 				choices: this.inputs,
 				default: 0,
@@ -63,14 +63,14 @@ exports.initFeedbacks = function () {
 		type: 'boolean',
 		label: 'Change style when player is active',
 		description: 'When media state is on play, button style will change',
-		style: feedbackColorProgram,
+		style: feedbackColorPreview,
 		options: [
 			{
 				type: 'dropdown',
-				label: 'target',
+				label: 'Media Player',
 				id: 'target',
-				choices: this.mediaTargets,
-				default: 'ddr1',
+				choices: this.mediaSourceNames,
+				default: 'ddr1_play',
 			},
 		],
 	}

--- a/index.js
+++ b/index.js
@@ -440,11 +440,11 @@ class instance extends instance_skel {
 			} else if (element['$']['name'].match(/record_toggle/)) {
 				this.switcher['recording'] = element['$']['value'] == '1' ? true : false
 				this.setVariable('recording', element['$']['value'] == '1' ? true : false)
-				this.checkFeedbacks['tally_record']
+				this.checkFeedbacks('tally_record')
 			} else if (element['$']['name'].match(/streaming_toggle/)) {
 				this.switcher['streaming'] = element['$']['value'] == '1' ? true : false
 				this.setVariable('streaming', element['$']['value'] == '1' ? true : false)
-				this.checkFeedbacks['tally_streaming']
+				this.checkFeedbacks('tally_streaming')
 			} else if (
 				element['$']['name'].match(/ddr1_play/) ||
 				element['$']['name'].match(/ddr2_play/) ||
@@ -452,7 +452,7 @@ class instance extends instance_skel {
 				element['$']['name'].match(/ddr4_play/)
 			) {
 				this.shortcut_states[element['$']['name']] == element['$']['value']
-				this.checkFeedbacks['play_media']
+				this.checkFeedbacks('play_media')
 			}
 		})
 		this.checkFeedbacks('tally_PVW')
@@ -705,7 +705,7 @@ class instance extends instance_skel {
 		}
 		this.checkFeedbacks('tally_PGM')
 		this.checkFeedbacks('tally_PVW')
-		this.checkFeedbacks['tally_streaming']
+		this.checkFeedbacks('tally_streaming')
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -477,9 +477,7 @@ class instance extends instance_skel {
 	 */
 	shortcutStatesIngest(states) {
 		states.forEach((element) => {
-			if (element['$']['name'] == 'preview_tally') {
-			} else if (element['$']['name'] == 'program_tally') {
-			} else if (element['$']['name'].match(/_short_name/)) {
+			if (element['$']['name'].match(/_short_name/)) {
 				const index = this.inputs.findIndex((el) => el.name == element['$']['name'].slice(0, -11))
 				if (index != -1) {
 					this.inputs[index].short_name = element['$']['value']
@@ -526,9 +524,8 @@ class instance extends instance_skel {
 				this.checkFeedbacks('play_media')
 			}
 		})
-		this.checkFeedbacks('tally_PVW')
-		this.checkFeedbacks('tally_PGM')
-		this.checkFeedbacks('tally_streaming')
+
+		this.sendGetRequest(`http://${this.config.host}/v1/dictionary?key=switcher`) // Fetch switcher changes for proper PGM/PVW button variable names on start-up
 	}
 	/**
 	 * @param  {} data
@@ -644,12 +641,6 @@ class instance extends instance_skel {
 				'pvw_source',
 				pvwSource?.short_name ? pvwSource.short_name : data['switcher_update']['$']['preview_source']
 			)
-
-			this.actions() // Set the actions after info is retrieved
-			this.init_feedbacks() // Same for feedback as it holds the inputs
-			this.init_presets()
-			this.checkFeedbacks('tally_PGM') // Check directly, which source is active
-			this.checkFeedbacks('tally_PVW') // Check directly, which source is on preview
 		} else if (data['macros'] !== undefined) {
 			// Fetch all macros
 			data['macros']['systemfolder']['macro'].forEach((element) => {

--- a/index.js
+++ b/index.js
@@ -62,16 +62,16 @@ class instance extends instance_skel {
 		for (let index = 1; index < 9; index++) {
 			this.meDestinations.push({
 				id: `v${index}_a_row`,
-				label: `v${index} a bus`,
+				label: `M/E ${index} PGM`,
 			})
 			this.meDestinations.push({
 				id: `v${index}_b_row`,
-				label: `v${index} b bus`,
+				label: `M/E ${index} PVW`,
 			})
 			for (let dsk = 1; dsk < 5; dsk++) {
 				this.dskDestinations.push({
 					id: `v${index}_dsk${dsk}`,
-					label: `v${index} dsk ${dsk}`,
+					label: `M/E ${index} DSK ${dsk}`,
 				})
 			}
 		}
@@ -92,31 +92,31 @@ class instance extends instance_skel {
 		for (let index = 1; index < 5; index++) {
 			this.mediaTargets.push({
 				id: `ddr${index}_play`,
-				label: `ddr${index} Play`,
+				label: `DDR ${index} Play`,
 			})
 			this.mediaTargets.push({
 				id: `ddr${index}_play_toggle`,
-				label: `ddr${index} Play Toggle`,
+				label: `DDR ${index} Play Toggle`,
 			})
 			this.mediaTargets.push({
 				id: `ddr${index}_stop`,
-				label: `ddr${index} Stop`,
+				label: `DDR ${index} Stop`,
 			})
 			this.mediaTargets.push({
 				id: `ddr${index}_back`,
-				label: `ddr${index} Back`,
+				label: `DDR ${index} Back`,
 			})
 			this.mediaTargets.push({
 				id: `ddr${index}_forward`,
-				label: `ddr${index} Forward`,
+				label: `DDR ${index} Forward`,
 			})
 			this.mediaTargets.push({
 				id: `ddr${index}_mark_in`,
-				label: `ddr${index} Mark In`,
+				label: `DDR ${index} Mark In`,
 			})
 			this.mediaTargets.push({
 				id: `ddr${index}_mark_out`,
-				label: `ddr${index} Mark Out`,
+				label: `DDR ${index} Mark Out`,
 			})
 			this.mediaSourceNames.push({
 				id: `ddr${index}_play`,
@@ -126,23 +126,23 @@ class instance extends instance_skel {
 		for (let index = 1; index < 3; index++) {
 			this.mediaTargets.push({
 				id: `gfx${index}_play`,
-				label: `gfx${index} Play`,
+				label: `GFX ${index} Play`,
 			})
 			this.mediaTargets.push({
 				id: `gfx${index}_play_toggle`,
-				label: `gfx${index} Play Toggle`,
+				label: `GFX ${index} Play Toggle`,
 			})
 			this.mediaTargets.push({
 				id: `gfx${index}_stop`,
-				label: `gfx${index} Stop`,
+				label: `GFX ${index} Stop`,
 			})
 			this.mediaTargets.push({
 				id: `gfx${index}_back`,
-				label: `gfx${index} Back`,
+				label: `GFX ${index} Back`,
 			})
 			this.mediaTargets.push({
 				id: `gfx${index}_forward`,
-				label: `gfx${index} Forward`,
+				label: `GFX ${index} Forward`,
 			})
 			this.mediaSourceNames.push({
 				id: `gfx${index}_play`,
@@ -151,7 +151,7 @@ class instance extends instance_skel {
 		}
 		this.mediaTargets.push({
 			id: `stills_play`,
-			label: `stills Play`,
+			label: `Stills Play`,
 		})
 		this.mediaSourceNames.push({
 			id: `stills_play`,
@@ -159,40 +159,40 @@ class instance extends instance_skel {
 		})
 		this.mediaTargets.push({
 			id: `stills_play_toggle`,
-			label: `stills Play Toggle`,
+			label: `Stills Play Toggle`,
 		})
 		this.mediaTargets.push({
 			id: `stills_stop`,
-			label: `stills Stop`,
+			label: `Stills Stop`,
 		})
 		this.mediaTargets.push({
 			id: `stills_back`,
-			label: `stills Back`,
+			label: `Stills Back`,
 		})
 		this.mediaTargets.push({
 			id: `stills_forward`,
-			label: `stills Forward`,
+			label: `Stills Forward`,
 		})
 
 		this.mediaTargets.push({
 			id: `titles_play`,
-			label: `titles Play`,
+			label: `Titles Play`,
 		})
 		this.mediaTargets.push({
 			id: `titles_play_toggle`,
-			label: `titles Play Toggle`,
+			label: `Titles Play Toggle`,
 		})
 		this.mediaTargets.push({
 			id: `titles_stop`,
-			label: `titles Stop`,
+			label: `Titles Stop`,
 		})
 		this.mediaTargets.push({
 			id: `titles_back`,
-			label: `titles Back`,
+			label: `Titles Back`,
 		})
 		this.mediaTargets.push({
 			id: `titles_forward`,
-			label: `titles Forward`,
+			label: `Titles Forward`,
 		})
 		this.mediaSourceNames.push({
 			id: `titles_play`,
@@ -556,20 +556,23 @@ class instance extends instance_skel {
 				let variables = []
 				console.log('Load initial Data')
 				data['tally']['column'].forEach((element) => {
-					this.inputs.push({
-						id: element['$']['index'],
-						label: element['$']['name'],
-						name: element['$']['name'],
-						long_name: element['$']['name'],
-						short_name: element['$']['name'],
-					})
-					element['$']['on_prev'] == 'true'
-						? (this.tallyPVW[element['$']['index']] = 'true')
-						: (this.tallyPVW[element['$']['index']] = 'false')
-					element['$']['on_pgm'] == 'true'
-						? (this.tallyPGM[element['$']['index']] = 'true')
-						: (this.tallyPGM[element['$']['index']] = 'false;')
-					variables.push({ name: `${element['$']['name']}`, label: element['$']['name'] })
+					//Prevent excess DDR/GFX A/B Inputs from being visible
+					if (!element['$']['name'].match(/[d,g][d,f][r,x][1-2](_)[a,b]/i)) {
+						this.inputs.push({
+							id: element['$']['index'],
+							label: element['$']['name'],
+							name: element['$']['name'],
+							long_name: element['$']['name'],
+							short_name: element['$']['name'],
+						})
+						element['$']['on_prev'] == 'true'
+							? (this.tallyPVW[element['$']['index']] = 'true')
+							: (this.tallyPVW[element['$']['index']] = 'false')
+						element['$']['on_pgm'] == 'true'
+							? (this.tallyPGM[element['$']['index']] = 'true')
+							: (this.tallyPGM[element['$']['index']] = 'false;')
+						variables.push({ name: `${element['$']['name']}`, label: element['$']['name'] })
+					}
 				})
 				this.set_variablesDefinition(variables)
 			}

--- a/index.js
+++ b/index.js
@@ -48,12 +48,12 @@ class instance extends instance_skel {
 	static GetUpgradeScripts() {
 		return [
 			instance_skel.CreateConvertToBooleanFeedbackUpgradeScript({
-				'tally_PGM': true,
-				'tally_PVW': true,
-				'tally_record': true,
-				'tally_streaming': true,
-				'play_media': true,
-			})
+				tally_PGM: true,
+				tally_PVW: true,
+				tally_record: true,
+				tally_streaming: true,
+				play_media: true,
+			}),
 		]
 	}
 
@@ -197,29 +197,22 @@ class instance extends instance_skel {
 			{
 				type: 'textinput',
 				id: 'host',
-				label: 'Target IP',
+				label: 'Tricaster IP',
 				width: 6,
 				regex: this.REGEX_IP,
 			},
 			{
 				type: 'text',
 				id: 'info',
-				width: 12,
-				label: 'Information',
-				value: 'We use polling to fetch datalink key/value pairs, see variables below for the values',
-			},
-			{
-				type: 'text',
-				id: 'info',
 				width: 10,
-				label: 'Information',
-				value: 'Put the polling interval in milliseconds here, 0 for off, minimal 500ms interval',
+				label: 'Polling Information',
+				value: 'Polling is required for DataLink variables (0 for off, interval must be 500ms or larger)',
 			},
 			{
 				type: 'textinput',
 				id: 'pollInterval',
-				label: 'Polling interval (0 for off)',
-				width: 2,
+				label: 'Polling Interval',
+				width: 4,
 				default: '0',
 			},
 		]
@@ -361,10 +354,9 @@ class instance extends instance_skel {
 			})
 			this.socket.on('error', (err) => {
 				if (err.errno === 'ECONNREFUSED') {
-					this.log("TCP error: " + err);
+					this.log('TCP error: ' + err)
 					this.status(this.STATE_ERROR, err)
-				}
-				else {
+				} else {
 					this.status(this.STATE_ERROR, err)
 					debug('Network error', err)
 					this.log('error', 'Network error: ' + err.message)
@@ -373,7 +365,7 @@ class instance extends instance_skel {
 
 			this.socket.on('connect', () => {
 				this.status(this.STATE_OK)
-				// Ask the mixer to give us variable (register/state) updates on connectc
+				// Ask the mixer to give us variable (register/state) updates on connection
 				this.socket.send(`<register name="NTK_states"/>\n`)
 
 				debug('TriCaster shortcut socket Opened')
@@ -396,7 +388,6 @@ class instance extends instance_skel {
 					}
 				})
 			})
-
 		}
 	}
 
@@ -514,11 +505,11 @@ class instance extends instance_skel {
 					this.processData(result.data)
 				} else if (result.response.statusCode == 401) {
 					// mmm password?
-					this.status(this.STATUS_ERROR, 'Password needed?')
-					this.log('error', 'Password? HTTP status code: ' + result.response.statusCode)
+					this.status(this.STATUS_ERROR)
+					this.log('error', 'On the Tricaster under Administration Tools, turn off the LivePanel password')
 				} else {
-					this.status(this.STATUS_ERROR, 'Unespected HTTP status code: ' + result.response.statusCode)
-					this.log('error', 'Unespected HTTP status code: ' + result.response.statusCode)
+					this.status(this.STATUS_ERROR, 'Unexpected HTTP status code: ' + result.response.statusCode)
+					this.log('error', 'Unexpected HTTP status code: ' + result.response.statusCode)
 				}
 			}
 		})
@@ -642,7 +633,7 @@ class instance extends instance_skel {
 				cmd = `<shortcuts><shortcut name="streaming_toggle" value="${parseInt(opt.force)}" /></shortcuts>`
 				this.switcher['streaming'] = opt.force == '1' ? true : false
 				this.setVariable('streaming', opt.force == '1' ? true : false)
-				console.log(cmd);
+				console.log(cmd)
 				break
 			case 'source_pgm':
 				cmd = `<shortcuts><shortcut name="main_a_row" value="${opt.source}" /></shortcuts>`

--- a/index.js
+++ b/index.js
@@ -398,24 +398,28 @@ class instance extends instance_skel {
 		states.forEach((element) => {
 			if (element['$']['name'] == 'preview_tally') {
 				this.tallyPVW = []
-				this.setVariable('pvw_source', element['$']['value'].toLowerCase().split('|'))
+				let sourceNames = []
 				element['$']['value']
 					.toLowerCase()
 					.split('|')
 					.forEach((element2) => {
 						const index = this.inputs.findIndex((el) => el.name == element2.toLowerCase())
 						if (index != -1) this.tallyPVW[this.inputs[index].id] = 'true'
+						sourceNames.push(this.inputs[index]?.short_name)
 					})
+				this.setVariable('pvw_source', sourceNames.join('\\n'))
 			} else if (element['$']['name'] == 'program_tally') {
 				this.tallyPGM = []
-				this.setVariable('pgm_source', element['$']['value'].toLowerCase().split('|'))
+				let sourceNames = []
 				element['$']['value']
 					.toLowerCase()
 					.split('|')
 					.forEach((element2) => {
 						const index = this.inputs.findIndex((el) => el.name == element2.toLowerCase())
 						if (index != -1) this.tallyPGM[this.inputs[index].id] = 'true'
+						sourceNames.push(this.inputs[index]?.short_name)
 					})
+				this.setVariable('pgm_source', sourceNames.join('\\n'))
 			} else if (element['$']['name'].match(/_short_name/)) {
 				const index = this.inputs.findIndex((el) => el.name == element['$']['name'].slice(0, -11))
 				if (index != -1) {

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ class instance extends instance_skel {
 		this.shortcut_states = []
 		this.variables = []
 		this.mediaTargets = []
+		this.mediaSourceNames = []
 		this.meDestinations = []
 		this.dskDestinations = []
 		this.createDskDestinations()
@@ -117,6 +118,10 @@ class instance extends instance_skel {
 				id: `ddr${index}_mark_out`,
 				label: `ddr${index} Mark Out`,
 			})
+			this.mediaSourceNames.push({
+				id: `ddr${index}_play`,
+				label: `DDR ${index}`,
+			})
 		}
 		for (let index = 1; index < 3; index++) {
 			this.mediaTargets.push({
@@ -139,10 +144,18 @@ class instance extends instance_skel {
 				id: `gfx${index}_forward`,
 				label: `gfx${index} Forward`,
 			})
+			this.mediaSourceNames.push({
+				id: `gfx${index}_play`,
+				label: `GFX ${index}`,
+			})
 		}
 		this.mediaTargets.push({
 			id: `stills_play`,
 			label: `stills Play`,
+		})
+		this.mediaSourceNames.push({
+			id: `stills_play`,
+			label: `Stills`,
 		})
 		this.mediaTargets.push({
 			id: `stills_play_toggle`,
@@ -180,6 +193,14 @@ class instance extends instance_skel {
 		this.mediaTargets.push({
 			id: `titles_forward`,
 			label: `titles Forward`,
+		})
+		this.mediaSourceNames.push({
+			id: `titles_play`,
+			label: `Titles`,
+		})
+		this.mediaSourceNames.push({
+			id: `sound_play`,
+			label: `Sound`,
 		})
 	}
 	/**
@@ -456,9 +477,14 @@ class instance extends instance_skel {
 				element['$']['name'].match(/ddr1_play/) ||
 				element['$']['name'].match(/ddr2_play/) ||
 				element['$']['name'].match(/ddr3_play/) ||
-				element['$']['name'].match(/ddr4_play/)
+				element['$']['name'].match(/ddr4_play/) ||
+				element['$']['name'].match(/gfx1_play/) ||
+				element['$']['name'].match(/gfx2_play/) ||
+				element['$']['name'].match(/stills_play/) ||
+				element['$']['name'].match(/titles_play/) ||
+				element['$']['name'].match(/sound_play/)
 			) {
-				this.shortcut_states[element['$']['name']] == element['$']['value']
+				this.shortcut_states[element['$']['name']] = element['$']['value']
 				this.checkFeedbacks('play_media')
 			}
 		})

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ class instance extends instance_skel {
 				label: `DDR ${index} Mark Out`,
 			})
 			this.mediaSourceNames.push({
-				id: `ddr${index}_play`,
+				id: `ddr${index}`,
 				label: `DDR ${index}`,
 			})
 		}
@@ -145,7 +145,7 @@ class instance extends instance_skel {
 				label: `GFX ${index} Forward`,
 			})
 			this.mediaSourceNames.push({
-				id: `gfx${index}_play`,
+				id: `gfx${index}`,
 				label: `GFX ${index}`,
 			})
 		}
@@ -154,7 +154,7 @@ class instance extends instance_skel {
 			label: `Stills Play`,
 		})
 		this.mediaSourceNames.push({
-			id: `stills_play`,
+			id: `stills`,
 			label: `Stills`,
 		})
 		this.mediaTargets.push({
@@ -195,11 +195,11 @@ class instance extends instance_skel {
 			label: `Titles Forward`,
 		})
 		this.mediaSourceNames.push({
-			id: `titles_play`,
+			id: `titles`,
 			label: `Titles`,
 		})
 		this.mediaSourceNames.push({
-			id: `sound_play`,
+			id: `sound`,
 			label: `Sound`,
 		})
 	}

--- a/index.js
+++ b/index.js
@@ -45,6 +45,18 @@ class instance extends instance_skel {
 		this.createMeDestinations()
 	}
 
+	static GetUpgradeScripts() {
+		return [
+			instance_skel.CreateConvertToBooleanFeedbackUpgradeScript({
+				'tally_PGM': true,
+				'tally_PVW': true,
+				'tally_record': true,
+				'tally_streaming': true,
+				'play_media': true,
+			})
+		]
+	}
+
 	createMeDestinations() {
 		for (let index = 1; index < 9; index++) {
 			this.meDestinations.push({

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ class instance extends instance_skel {
 		this.switcher = []
 		this.inputs = []
 		this.system_macros = []
+		this.custom_macros = []
 		this.tally = []
 		this.tallyPVW = []
 		this.tallyPGM = []
@@ -649,6 +650,14 @@ class instance extends instance_skel {
 					label: element['$']['name'],
 				})
 			})
+			data['macros']['folder']?.forEach((folder) => {
+				folder.macro?.forEach((macro) => {
+					this.custom_macros.push({
+						id: macro['$']['name'],
+						label: macro['$']['name'],
+					})
+				})
+			})
 			this.actions() // Reset the actions, marco's could be updated
 		} else if (data['shortcut_states'] !== undefined) {
 			// Handled by TCP states
@@ -768,10 +777,7 @@ class instance extends instance_skel {
 				cmd = opt.custom
 				break
 			case 'trigger':
-				this.debug(`http://${this.config.host}/v1/trigger?name=${opt.macro}`)
-				this.system.emit('rest_get', `http://${this.config.host}/v1/trigger?name=${opt.macro}`, (err, res) => {
-					this.debug(res)
-				})
+				cmd = `<shortcuts><shortcut name="play_macro_byname" value="${opt.macro}"/></shortcuts>`
 				break
 		}
 

--- a/presets.js
+++ b/presets.js
@@ -104,7 +104,7 @@ exports.getPresets = function () {
 		label: 'STREAM',
 		bank: {
 			style: 'text',
-			text: 'Stream on',
+			text: 'Stream On',
 			size: '14',
 			color: foregroundColor,
 			bgcolor: backgroundColor,
@@ -132,7 +132,7 @@ exports.getPresets = function () {
 		label: 'STREAM',
 		bank: {
 			style: 'text',
-			text: 'Stream off',
+			text: 'Stream Off',
 			size: '14',
 			color: foregroundColor,
 			bgcolor: backgroundColor,
@@ -230,7 +230,7 @@ exports.getPresets = function () {
 		 * Source on ME/1
 		 */
 		presets.push({
-			category: 'Source on V1',
+			category: 'Source on M/E 1',
 			label: element.label,
 			bank: {
 				style: 'text',

--- a/presets.js
+++ b/presets.js
@@ -251,5 +251,80 @@ exports.getPresets = function () {
 		})
 	})
 
+	this.mediaSourceNames.forEach((source) => {
+		/**
+		 * Source on PGM
+		 */
+		presets.push({
+			category: 'Media Players',
+			label: `${source.label} Toggle Play`,
+			bank: {
+				style: 'text',
+				text: `${source.label} Toggle Play`,
+				size: '14',
+				color: foregroundColor,
+				bgcolor: backgroundColor,
+			},
+			feedbacks: [
+				{
+					type: 'play_media',
+					options: {
+						target: `${source.id}_play`,
+					},
+					style: {
+						bgcolor: this.rgb(0, 255, 0),
+						color: this.rgb(255, 255, 255),
+					},
+				},
+			],
+			actions: [
+				{
+					action: 'media_target',
+					options: {
+						target: `${source.id}_play_toggle`,
+					},
+				},
+			],
+		})
+		presets.push({
+			category: 'Media Players',
+			label: `${source.label} Back`,
+			bank: {
+				style: 'text',
+				text: `${source.label} Back`,
+				size: '14',
+				color: foregroundColor,
+				bgcolor: backgroundColor,
+			},
+			actions: [
+				{
+					action: 'media_target',
+					options: {
+						target: `${source.id}_back`,
+					},
+				},
+			],
+		})
+		presets.push({
+			category: 'Media Players',
+			label: `${source.label} Forward`,
+			bank: {
+				style: 'text',
+				text: `${source.label} Forward`,
+				size: '14',
+				color: foregroundColor,
+				bgcolor: backgroundColor,
+			},
+			actions: [
+				{
+					action: 'media_target',
+					options: {
+						target: `${source.id}_forward`,
+					},
+				},
+			],
+		})
+	})
+
 	return presets
 }

--- a/presets.js
+++ b/presets.js
@@ -79,9 +79,9 @@ exports.getPresets = function () {
 		feedbacks: [
 			{
 				type: 'tally_record',
-				options: {
-					bg: this.rgb(255, 0, 0),
-					fg: this.rgb(255, 255, 255),
+				style: {
+					bgcolor: this.rgb(255, 0, 0),
+					color: this.rgb(255, 255, 255),
 				},
 			},
 		],
@@ -112,9 +112,9 @@ exports.getPresets = function () {
 		feedbacks: [
 			{
 				type: 'tally_streaming',
-				options: {
-					bg: this.rgb(255, 0, 0),
-					fg: this.rgb(255, 255, 255),
+				style: {
+					bgcolor: this.rgb(255, 0, 0),
+					color: this.rgb(255, 255, 255),
 				},
 			},
 		],
@@ -140,9 +140,9 @@ exports.getPresets = function () {
 		feedbacks: [
 			{
 				type: 'tally_streaming',
-				options: {
-					bg: this.rgb(255, 0, 0),
-					fg: this.rgb(255, 255, 255),
+				style: {
+					bgcolor: this.rgb(255, 0, 0),
+					color: this.rgb(255, 255, 255),
 				},
 			},
 		],
@@ -175,9 +175,11 @@ exports.getPresets = function () {
 				{
 					type: 'tally_PGM',
 					options: {
-						bg: this.rgb(255, 0, 0),
-						fg: this.rgb(0, 0, 0),
 						src: element.id,
+					},
+					style: {
+						bgcolor: this.rgb(255, 0, 0),
+						color: this.rgb(255, 255, 255),
 					},
 				},
 			],
@@ -207,9 +209,11 @@ exports.getPresets = function () {
 				{
 					type: 'tally_PVW',
 					options: {
-						bg: this.rgb(255, 255, 0),
-						fg: this.rgb(0, 0, 0),
 						src: element.id,
+					},
+					style: {
+						bgcolor: this.rgb(0, 255, 0),
+						color: this.rgb(255, 255, 255),
 					},
 				},
 			],


### PR DESCRIPTION
New
- Ability to run custom macros by name (closes https://github.com/bitfocus/companion-module-newtek-tricaster/issues/8)
- Boolean feedbacks
- Added presets related to media players

Minor
- Matched labels to more closely represent Tricaster naming conventions
- Use source short names instead of input number for tally variable
- Updated help docs for information about set-up procedure
- Improved tally handling (closes https://github.com/bitfocus/companion-module-newtek-tricaster/issues/4)
- Removed unused DDR_a, _b options (closes https://github.com/bitfocus/companion-module-newtek-tricaster/issues/14)

Fixes
- Rec/Stream feedback now works reliably
- Media Player feedbacks now works
- PGM/ PRV Variable is now correct (closes https://github.com/bitfocus/companion-module-newtek-tricaster/issues/5)
